### PR TITLE
update workflows to use supported OS

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master ]
 jobs:
   sync_submodule_capa:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     # Do not checkout submodules as we don't need capa-rules and we need to
     # update the tests/data submodule reference

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # file name consistency
   test_filenames:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout testfiles repository
       uses: actions/checkout@b80ff79f1755d06ba70441c368a6fe801f5f3a62 # v4.1.6
@@ -21,7 +21,7 @@ jobs:
       run: python .github/check_sample_filenames.py .
   # to allow quicker tests, capa should run less than THRESHOLD seconds on added/modified test files
   test_runtime:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     # We check the submodules separately as the rules submodule's reference may not be our PR/master
     - name: Checkout capa without submodules


### PR DESCRIPTION
tests on https://github.com/mandiant/capa-testfiles/pull/283 failed because 20.04 has no runners anymore:

https://github.com/mandiant/capa-testfiles/actions/runs/14976225155/job/42069153015?pr=283

> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

this PR bumps it to `ubuntu-latest`, mirroring what is setup in the `capa-rules` repo